### PR TITLE
Fix an issue when content_to_trans is empty

### DIFF
--- a/autosub/core.py
+++ b/autosub/core.py
@@ -769,7 +769,10 @@ def list_to_googletrans(  # pylint: disable=too-many-locals, too-many-arguments,
 
     if translator != ManualTranslator and src_language == "auto":
         content_to_trans = '\n'.join(text_list[i:partial_index[0]])
-        result_src = translator.detect(content_to_trans).lang
+        if len(content_to_trans) > 0:
+            result_src = translator.detect(content_to_trans).lang
+        else:
+            result_src = ""
     else:
         result_src = src_language
 


### PR DESCRIPTION
The text returned from google speech_to_text can be empty. In this case, an error is thrown during translation : 
```
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```